### PR TITLE
Vagrant: add LXC as provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ Web application for working with stratigraphic data
 Development
 -----------
 
-The stratigy project is using Vagrant as development environment. It provides an
-interface for handling different providers, in this case Virtualbox.
+The stratigy project is using Vagrant as development environment. It
+provides an interface for handling different providers, in this case
+Virtualbox and LXC. Virtualbox is the generic option, because it works
+on all platforms. LXC just works on Linux, but has the advantage of not
+virtualizing a complete guest system, but using the kernel of the host
+instead, which saves a lot of ressources on the host.
 The properties of the virtual machine are configured in the Vagrantfile.
 
 ### Setup Development Environment
@@ -27,7 +31,7 @@ The properties of the virtual machine are configured in the Vagrantfile.
 
  ```bash
  # start or resume virtual machine (runs the provisioning, if there wasnt a saved state) :
- vagrant up
+ vagrant up [--provider=lxc]
  # ssh into virtual machine as user vagrant:
  vagrant ssh
  # save virtual machine and turn off

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,11 +1,20 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty32"
+
+  config.vm.box = "fgrehm/trusty64-lxc"
+
   config.vm.synced_folder ".", "/vagrant"
+
   config.vm.network :forwarded_port, host: 5000, guest: 5000
   config.vm.network :forwarded_port, host: 5433, guest: 5432
-  config.vm.provider :virtualbox do |v|
-    v.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
-    v.memory = 512
+
+  config.vm.provider :virtualbox do |vb|
+    vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
+    vb.memory = 300
   end
+
+  config.vm.provider :lxc do |lxc|
+    lxc.customize 'cgroup.memory.limit_in_bytes', '300M'
+  end
+
   config.vm.provision "shell", path: "provisioning/provision.sh"
 end


### PR DESCRIPTION
LXC (Linux Containers) is the native way to have containers without virtualization on Linux. By adding this as an optional provider, Linux users should be able to save significant amounts of host ressources when developing with vagrant on the stratigy project.
